### PR TITLE
Add support for excluding files in the build directory

### DIFF
--- a/src/main/groovy/org/cadixdev/gradle/licenser/LicenseExtension.groovy
+++ b/src/main/groovy/org/cadixdev/gradle/licenser/LicenseExtension.groovy
@@ -68,6 +68,13 @@ class LicenseExtension extends LicenseProperties {
     boolean ignoreFailures = false
 
     /**
+     * Whether to include source files in the build directory (most likely
+     * generated code). This does not affect custom tasks.
+     * By default this is {@code false}.
+     */
+    boolean includeBuild = false
+
+    /**
      * The style mappings from file extension to the type of style of the
      * comment header for the license header.
      * By default this includes mappings and styles for the most common file


### PR DESCRIPTION
Most likely, these files are generated or downloaded external code. In the former case, licensing information should be generated by the code generator; in the latter, the license should remain untouched.

This is controlled by the extension property “includeBuild”, defaulting to true (this could be change to false to keep the former behavior). Personally, I have not encountered a situation where I would want generated files to be rewritten.