### PR TITLE
Dog-food org.cadixdev.licenser 0.5.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
     id 'com.gradle.plugin-publish' version '0.12.0'
 
-    id 'net.minecrell.licenser' version '0.4.1'
+    id 'org.cadixdev.licenser' version '0.5.0'
 }
 
 sourceCompatibility = '1.8'


### PR DESCRIPTION
Use the latest released version of `org.cadixdev.licenser` to check the license headers of this project.