### PR TITLE
Fix setting custom header styles

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,8 +14,31 @@ group = 'org.cadixdev.gradle'
 version = '0.5.0'
 description = 'A simple license header manager for Gradle'
 
+repositories {
+    mavenCentral()
+}
+
 dependencies {
     implementation gradleApi()
+
+    testImplementation 'org.spockframework:spock-core:1.3-groovy-2.5'
+}
+
+sourceSets {
+    functionalTest {
+    }
+}
+gradlePlugin.testSourceSets(sourceSets.functionalTest)
+configurations.functionalTestImplementation.extendsFrom(configurations.testImplementation)
+
+tasks.register('functionalTest', Test) {
+    testClassesDirs = sourceSets.functionalTest.output.classesDirs
+    classpath = sourceSets.functionalTest.runtimeClasspath
+}
+
+tasks.named('check') {
+    // Run the functional tests as part of `check`
+    dependsOn(tasks.functionalTest)
 }
 
 license {

--- a/build.gradle
+++ b/build.gradle
@@ -18,27 +18,40 @@ repositories {
     mavenCentral()
 }
 
-dependencies {
-    implementation gradleApi()
-
-    testImplementation 'org.spockframework:spock-core:1.3-groovy-2.5'
-}
-
 sourceSets {
     functionalTest {
     }
 }
+
+configurations {
+    functionalTestImplementation.extendsFrom(testImplementation)
+    functionalTestRuntimeOnly.extendsFrom(testRuntimeOnly)
+}
 gradlePlugin.testSourceSets(sourceSets.functionalTest)
-configurations.functionalTestImplementation.extendsFrom(configurations.testImplementation)
 
 tasks.register('functionalTest', Test) {
+    description = 'Runs the functional tests.'
+    group = 'verification'
+
     testClassesDirs = sourceSets.functionalTest.output.classesDirs
     classpath = sourceSets.functionalTest.runtimeClasspath
+
+    mustRunAfter test
+}
+
+dependencies {
+    implementation gradleApi()
+
+    testImplementation 'org.spockframework:spock-core:1.3-groovy-2.5'
+    functionalTestImplementation gradleTestKit()
+}
+
+test {
+    useJUnit()
 }
 
 tasks.named('check') {
-    // Run the functional tests as part of `check`
-    dependsOn(tasks.functionalTest)
+    dependsOn(functionalTest)
 }
 
 license {

--- a/src/functionalTest/groovy/org/cadixdev/gradle/licenser/LicenserPluginFunctionalTest.groovy
+++ b/src/functionalTest/groovy/org/cadixdev/gradle/licenser/LicenserPluginFunctionalTest.groovy
@@ -1,0 +1,156 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015, Minecrell <https://github.com/Minecrell>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.cadixdev.gradle.licenser
+
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+class LicenserPluginFunctionalTest extends Specification {
+    @Rule
+    TemporaryFolder temporaryFolder = new TemporaryFolder()
+
+    def "can run licenseCheck task"() {
+        given:
+        def projectDir = temporaryFolder.newFolder()
+        new File(projectDir, "settings.gradle") << ""
+        new File(projectDir, "build.gradle") << """
+            plugins {
+                id('org.cadixdev.licenser')
+            }
+        """.stripIndent()
+
+        when:
+        def runner = GradleRunner.create()
+        runner.forwardOutput()
+        runner.withPluginClasspath()
+        runner.withArguments("licenseCheck")
+        runner.withProjectDir(projectDir)
+        def result = runner.build()
+
+        then:
+        result.task(":checkLicenses").outcome == TaskOutcome.UP_TO_DATE
+        result.task(":licenseCheck").outcome == TaskOutcome.UP_TO_DATE
+    }
+
+    def "can run licenseFormat task"() {
+        given:
+        def projectDir = temporaryFolder.newFolder()
+        new File(projectDir, "settings.gradle") << ""
+        new File(projectDir, "build.gradle") << """
+            plugins {
+                id('org.cadixdev.licenser')
+            }
+        """.stripIndent()
+
+        when:
+        def runner = GradleRunner.create()
+        runner.forwardOutput()
+        runner.withPluginClasspath()
+        runner.withArguments("licenseFormat")
+        runner.withProjectDir(projectDir)
+        def result = runner.build()
+
+        then:
+        result.output.contains("Task :updateLicenses UP-TO-DATE")
+        result.output.contains("Task :licenseFormat UP-TO-DATE")
+        result.task(":updateLicenses").outcome == TaskOutcome.UP_TO_DATE
+        result.task(":licenseFormat").outcome == TaskOutcome.UP_TO_DATE
+    }
+
+    def "supports custom source sets task"() {
+        given:
+        def projectDir = temporaryFolder.newFolder()
+        new File(projectDir, "settings.gradle") << ""
+        new File(projectDir, "build.gradle") << """
+            plugins {
+                id('org.cadixdev.licenser')
+                id('java')
+            }
+            sourceSets {
+                mySourceSet {}
+            }
+        """.stripIndent()
+
+        when:
+        def runner = GradleRunner.create()
+        runner.forwardOutput()
+        runner.withPluginClasspath()
+        runner.withArguments("licenseCheck")
+        runner.withProjectDir(projectDir)
+        def result = runner.build()
+
+        then:
+        result.task(":checkLicenseMySourceSet").outcome == TaskOutcome.NO_SOURCE
+    }
+
+    def "supports custom style"() {
+        given:
+        def projectDir = temporaryFolder.newFolder()
+        def sourcesDir = new File(projectDir, "sources")
+        sourcesDir.mkdirs()
+        new File(projectDir, "settings.gradle") << ""
+        new File(projectDir, "header.txt") << "Copyright header"
+        def sourceFile = new File(sourcesDir, "source.c") << "TEST"
+        new File(projectDir, "build.gradle") << """
+            plugins {
+                id('org.cadixdev.licenser')
+            }
+            
+            license {
+                header = project.file("header.txt")
+                style {
+                    c = 'BLOCK_COMMENT'
+                }
+                tasks {
+                    sources {
+                        files = project.files("sources")
+                        include("**/*.c")
+                    }
+                }
+            }
+        """.stripIndent()
+
+        when:
+        def runner = GradleRunner.create()
+        runner.forwardOutput()
+        runner.withPluginClasspath()
+        runner.withArguments("updateLicenses")
+        runner.withProjectDir(projectDir)
+        def result = runner.build()
+
+        then:
+        result.task(":updateLicenseCustomSources").outcome == TaskOutcome.SUCCESS
+        sourceFile.text == """\
+            /*
+             * Copyright header
+             */
+             
+            TEST
+            """.stripIndent()
+    }
+}

--- a/src/main/groovy/org/cadixdev/gradle/licenser/LicenseExtension.groovy
+++ b/src/main/groovy/org/cadixdev/gradle/licenser/LicenseExtension.groovy
@@ -176,7 +176,7 @@ class LicenseExtension extends LicenseProperties {
      * @param closure The closure to apply to the style
      */
     void style(@DelegatesTo(HeaderFormatRegistry) Closure closure) {
-        ConfigureUtil.configure(closure, style)
+        style.with(closure)
     }
 
     /**

--- a/src/test/groovy/org/cadixdev/gradle/licenser/LicenseExtensionTest.groovy
+++ b/src/test/groovy/org/cadixdev/gradle/licenser/LicenseExtensionTest.groovy
@@ -1,0 +1,46 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015, Minecrell <https://github.com/Minecrell>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.cadixdev.gradle.licenser
+
+
+import org.cadixdev.gradle.licenser.header.HeaderStyle
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Specification
+
+class LicenseExtensionTest extends Specification {
+    def "style closure registers header style"() {
+        given:
+        def project = ProjectBuilder.builder().build()
+        def licenseExtension = new LicenseExtension(project)
+
+        when:
+        licenseExtension.style {
+            ext = 'BLOCK_COMMENT'
+        }
+
+        then:
+        licenseExtension.style.getProperty("ext") == HeaderStyle.BLOCK_COMMENT.format
+    }
+}

--- a/src/test/groovy/org/cadixdev/gradle/licenser/LicenseExtensionTest.groovy
+++ b/src/test/groovy/org/cadixdev/gradle/licenser/LicenseExtensionTest.groovy
@@ -24,7 +24,6 @@
 
 package org.cadixdev.gradle.licenser
 
-
 import org.cadixdev.gradle.licenser.header.HeaderStyle
 import org.gradle.testfixtures.ProjectBuilder
 import spock.lang.Specification

--- a/src/test/groovy/org/cadixdev/gradle/licenser/LicenserPluginTest.groovy
+++ b/src/test/groovy/org/cadixdev/gradle/licenser/LicenserPluginTest.groovy
@@ -37,7 +37,7 @@ class LicenserPluginTest extends Specification {
 
         then:
         ["licenseCheck", "licenseFormat", "checkLicenses", "updateLicenses"].each {
-            project.tasks.findByName(it) != null
+            assert project.tasks.findByName(it) != null
         }
     }
 }

--- a/src/test/groovy/org/cadixdev/gradle/licenser/LicenserPluginTest.groovy
+++ b/src/test/groovy/org/cadixdev/gradle/licenser/LicenserPluginTest.groovy
@@ -1,0 +1,43 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015, Minecrell <https://github.com/Minecrell>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.cadixdev.gradle.licenser
+
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Specification
+
+class LicenserPluginTest extends Specification {
+    def "plugin registers tasks"() {
+        given:
+        def project = ProjectBuilder.builder().build()
+
+        when:
+        project.plugins.apply("org.cadixdev.licenser")
+
+        then:
+        ["licenseCheck", "licenseFormat", "checkLicenses", "updateLicenses"].each {
+            project.tasks.findByName(it) != null
+        }
+    }
+}

--- a/src/test/groovy/org/cadixdev/gradle/licenser/header/HeaderFormatRegistryTest.groovy
+++ b/src/test/groovy/org/cadixdev/gradle/licenser/header/HeaderFormatRegistryTest.groovy
@@ -1,0 +1,40 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015, Minecrell <https://github.com/Minecrell>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.cadixdev.gradle.licenser.header
+
+
+import spock.lang.Specification
+
+class HeaderFormatRegistryTest extends Specification {
+    def "registry contains default properties"() {
+        when:
+        def registry = new HeaderFormatRegistry()
+
+        then:
+        ["java", "js", "kt", "groovy", "yml", "xml", "html"].each {
+            registry.getProperty(it) != null
+        }
+    }
+}

--- a/src/test/groovy/org/cadixdev/gradle/licenser/header/HeaderFormatRegistryTest.groovy
+++ b/src/test/groovy/org/cadixdev/gradle/licenser/header/HeaderFormatRegistryTest.groovy
@@ -24,7 +24,6 @@
 
 package org.cadixdev.gradle.licenser.header
 
-
 import spock.lang.Specification
 
 class HeaderFormatRegistryTest extends Specification {
@@ -33,8 +32,6 @@ class HeaderFormatRegistryTest extends Specification {
         def registry = new HeaderFormatRegistry()
 
         then:
-        ["java", "js", "kt", "groovy", "yml", "xml", "html"].each {
-            registry.getProperty(it) != null
-        }
+        registry.keySet().containsAll(["java", "js", "kt", "groovy", "yml", "xml", "html"])
     }
 }


### PR DESCRIPTION
Fix overriding or inserting new header styles via the `styles` property of `LicenseExtension`.

Additionally add the infrastructure for unit and functional tests and add some tests to verify the plugin is working.

Fixes #10