### PR TITLE
Add option to skip existing headers in files

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,13 @@ The plugin can be configured using the `license` extension on the project.
         newLine = false // Disables the new line
     }
     ```
+- **Ignore existing license headers:** (Default: false)
+
+    ```gradle
+    license {
+        skipExistingHeaders = true // Ignore existing license headers on files
+    }
+    ```
 - **Exclude/include certain file types:** (Default: Excludes files without standard comment format and binary files)
 
     ```gradle

--- a/src/main/groovy/org/cadixdev/gradle/licenser/LicenseExtension.groovy
+++ b/src/main/groovy/org/cadixdev/gradle/licenser/LicenseExtension.groovy
@@ -68,6 +68,13 @@ class LicenseExtension extends LicenseProperties {
     boolean ignoreFailures = false
 
     /**
+     * Whether to skip existing license headers instead of failing the build or
+     * updating the license headers.
+     * By default this is {@code false}.
+     */
+    boolean skipExistingHeaders = false
+
+    /**
      * The style mappings from file extension to the type of style of the
      * comment header for the license header.
      * By default this includes mappings and styles for the most common file

--- a/src/main/groovy/org/cadixdev/gradle/licenser/Licenser.groovy
+++ b/src/main/groovy/org/cadixdev/gradle/licenser/Licenser.groovy
@@ -149,6 +149,7 @@ class Licenser implements Plugin<Project> {
             task.files = files
             task.filter = extension.filter
             task.charset = extension.charset
+            task.skipExistingHeaders = extension.skipExistingHeaders
         }
     }
 

--- a/src/main/groovy/org/cadixdev/gradle/licenser/header/CommentHeaderFormat.groovy
+++ b/src/main/groovy/org/cadixdev/gradle/licenser/header/CommentHeaderFormat.groovy
@@ -26,6 +26,7 @@ package org.cadixdev.gradle.licenser.header
 
 import org.cadixdev.gradle.licenser.util.HeaderHelper
 
+import javax.annotation.Nullable
 import java.util.regex.Pattern
 
 class CommentHeaderFormat implements HeaderFormat {
@@ -33,14 +34,17 @@ class CommentHeaderFormat implements HeaderFormat {
     final String name
 
     final Pattern start
+    @Nullable
     final Pattern end
+    @Nullable
     final Pattern skipLine
 
     final String firstLine
     final String prefix
     final String lastLine
 
-    CommentHeaderFormat(String name, Pattern start, Pattern end, Pattern skipLine, String firstLine, String prefix, String lastLine) {
+    CommentHeaderFormat(String name, Pattern start, @Nullable Pattern end, @Nullable Pattern skipLine,
+                        String firstLine, String prefix, String lastLine) {
         this.name = name
         this.start = start
         this.end = end

--- a/src/main/groovy/org/cadixdev/gradle/licenser/header/HeaderStyle.groovy
+++ b/src/main/groovy/org/cadixdev/gradle/licenser/header/HeaderStyle.groovy
@@ -24,6 +24,7 @@
 
 package org.cadixdev.gradle.licenser.header
 
+import javax.annotation.Nullable
 import java.util.regex.Pattern
 
 enum HeaderStyle {
@@ -37,7 +38,8 @@ enum HeaderStyle {
     final CommentHeaderFormat format
     private final String[] extensions
 
-    HeaderStyle(Pattern start, Pattern end, Pattern skipLine, String firstLine, String prefix, String lastLine, String... extensions) {
+    HeaderStyle(Pattern start, @Nullable Pattern end, @Nullable Pattern skipLine,
+                String firstLine, String prefix, String lastLine, String... extensions) {
         this.format = new CommentHeaderFormat(this.name(), start, end, skipLine, firstLine, prefix, lastLine)
         this.extensions = extensions
     }

--- a/src/main/groovy/org/cadixdev/gradle/licenser/header/PreparedCommentHeader.groovy
+++ b/src/main/groovy/org/cadixdev/gradle/licenser/header/PreparedCommentHeader.groovy
@@ -73,6 +73,7 @@ class PreparedCommentHeader implements PreparedHeader {
         // need to append after it
         file.withReader(charset) { BufferedReader reader ->
             if (skipExistingHeaders) {
+                reader.mark(2048)
                 def startsWithValidHeader = HeaderHelper.contentStartsWithValidHeaderFormat(reader, format)
                 if (startsWithValidHeader) {
                     valid = true

--- a/src/main/groovy/org/cadixdev/gradle/licenser/header/PreparedHeader.java
+++ b/src/main/groovy/org/cadixdev/gradle/licenser/header/PreparedHeader.java
@@ -29,8 +29,8 @@ import java.io.IOException;
 
 public interface PreparedHeader {
 
-    boolean check(File file, String charset) throws IOException;
+    boolean check(File file, String charset, boolean skipExistingHeaders) throws IOException;
 
-    boolean update(File file, String charset, Runnable callback) throws IOException;
+    boolean update(File file, String charset, boolean skipExistingHeaders, Runnable callback) throws IOException;
 
 }

--- a/src/main/groovy/org/cadixdev/gradle/licenser/tasks/LicenseCheck.groovy
+++ b/src/main/groovy/org/cadixdev/gradle/licenser/tasks/LicenseCheck.groovy
@@ -67,7 +67,7 @@ class LicenseCheck extends LicenseTask implements VerificationTask {
                         return
                     }
 
-                    if (!prepared.check(file, charset)) {
+                    if (!prepared.check(file, charset, skipExistingHeaders)) {
                         violations.add(file)
                     }
                 } catch (Exception e) {

--- a/src/main/groovy/org/cadixdev/gradle/licenser/tasks/LicenseTask.groovy
+++ b/src/main/groovy/org/cadixdev/gradle/licenser/tasks/LicenseTask.groovy
@@ -50,6 +50,9 @@ class LicenseTask extends DefaultTask {
     @Input
     String charset
 
+    @Input
+    boolean skipExistingHeaders
+
     @InputFiles
     @SkipWhenEmpty
     FileTree getMatchingFiles() {

--- a/src/main/groovy/org/cadixdev/gradle/licenser/tasks/LicenseUpdate.groovy
+++ b/src/main/groovy/org/cadixdev/gradle/licenser/tasks/LicenseUpdate.groovy
@@ -53,7 +53,7 @@ class LicenseUpdate extends LicenseTask {
                         return
                     }
 
-                    if (prepared.update(file, charset, {
+                    if (prepared.update(file, charset, skipExistingHeaders, {
                         def backup = details.relativePath.getFile(original)
                         if (backup.exists()) {
                             assert backup.delete(), "Failed to delete backup file: $backup"

--- a/src/test/groovy/org/cadixdev/gradle/licenser/util/HeaderHelperTest.groovy
+++ b/src/test/groovy/org/cadixdev/gradle/licenser/util/HeaderHelperTest.groovy
@@ -1,0 +1,164 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015, Minecrell <https://github.com/Minecrell>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.cadixdev.gradle.licenser.util
+
+
+import org.cadixdev.gradle.licenser.header.HeaderStyle
+import spock.lang.Specification
+
+class HeaderHelperTest extends Specification {
+    def "contentStartsWithValidHeaderFormat returns false with empty input"() {
+        given:
+        def inputString = ""
+        def stringReader = new StringReader(inputString)
+        def reader = new BufferedReader(stringReader)
+
+        when:
+        def result = HeaderHelper.contentStartsWithValidHeaderFormat(reader, HeaderStyle.BLOCK_COMMENT.format)
+
+        then:
+        !result
+    }
+
+    def "contentStartsWithValidHeaderFormat returns false with non-matching input"() {
+        given:
+        def inputString = "Not a copyright header"
+        def stringReader = new StringReader(inputString)
+        def reader = new BufferedReader(stringReader)
+
+        when:
+        def result = HeaderHelper.contentStartsWithValidHeaderFormat(reader, HeaderStyle.BLOCK_COMMENT.format)
+
+        then:
+        !result
+    }
+
+    def "contentStartsWithValidHeaderFormat returns true with valid non-empty header"() {
+        given:
+        def inputString = """\
+            /*
+             * Some copyright header
+             */
+            My Content
+        """.stripIndent()
+        def stringReader = new StringReader(inputString)
+        def reader = new BufferedReader(stringReader)
+
+        when:
+        def result = HeaderHelper.contentStartsWithValidHeaderFormat(reader, HeaderStyle.BLOCK_COMMENT.format)
+
+        then:
+        result
+    }
+
+    def "contentStartsWithValidHeaderFormat returns false with invalid non-empty header"() {
+        given:
+        def inputString = """\
+            /**
+             * Some copyright header
+             */
+            My Content
+        """.stripIndent()
+        def stringReader = new StringReader(inputString)
+        def reader = new BufferedReader(stringReader)
+
+        when:
+        def result = HeaderHelper.contentStartsWithValidHeaderFormat(reader, HeaderStyle.BLOCK_COMMENT.format)
+
+        then:
+        !result
+    }
+
+    def "contentStartsWithValidHeaderFormat returns true with valid empty header"() {
+        given:
+        def inputString = """\
+            /*
+             */
+            My Content
+        """.stripIndent()
+        def stringReader = new StringReader(inputString)
+        def reader = new BufferedReader(stringReader)
+
+        when:
+        def result = HeaderHelper.contentStartsWithValidHeaderFormat(reader, HeaderStyle.BLOCK_COMMENT.format)
+
+        then:
+        result
+    }
+
+    def "contentStartsWithValidHeaderFormat returns false with incomplete header"() {
+        given:
+        def inputString = """\
+            /*
+             * Incomplete copyright header
+            My Content
+        """.stripIndent()
+        def stringReader = new StringReader(inputString)
+        def reader = new BufferedReader(stringReader)
+
+        when:
+        def result = HeaderHelper.contentStartsWithValidHeaderFormat(reader, HeaderStyle.BLOCK_COMMENT.format)
+
+        then:
+        !result
+    }
+
+    def "contentStartsWithValidHeaderFormat returns true with valid header with ignored lines"() {
+        given:
+        def inputString = """\
+            #!/bin/bash
+            # Some header
+            My Content
+        """.stripIndent()
+        def stringReader = new StringReader(inputString)
+        def reader = new BufferedReader(stringReader)
+
+        when:
+        def result = HeaderHelper.contentStartsWithValidHeaderFormat(reader, HeaderStyle.HASH.format)
+
+        then:
+        result
+    }
+
+    def "contentStartsWithValidHeaderFormat returns true with valid header with XML"() {
+        given:
+        def inputString = """\
+            <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+            <!--
+               Some copyright header
+            -->
+            <document>
+            </document>
+        """.stripIndent()
+        def stringReader = new StringReader(inputString)
+        def reader = new BufferedReader(stringReader)
+
+        when:
+        def result = HeaderHelper.contentStartsWithValidHeaderFormat(reader, HeaderStyle.XML.format)
+
+        then:
+        result
+    }
+}


### PR DESCRIPTION
The new `skipExistingHeaders` configuration setting allows to skip over files that already have some header conforming to the configured header style, which might not be the one specified in the header parameter.