### PR TITLE
Make missing headers/header formats less noisy

### DIFF
--- a/src/main/groovy/org/cadixdev/gradle/licenser/tasks/LicenseTask.groovy
+++ b/src/main/groovy/org/cadixdev/gradle/licenser/tasks/LicenseTask.groovy
@@ -93,7 +93,7 @@ abstract class LicenseTask extends DefaultTask {
     protected PreparedHeader prepareMatchingHeader(FileTreeElement element, File file) {
         def header = getMatchingHeader(element)
         if (header == null) {
-            logger.warn("No matching header found for {}", getSimplifiedPath(file))
+            logger.info("No matching header found for {}", getSimplifiedPath(file))
             return null
         }
 
@@ -103,7 +103,7 @@ abstract class LicenseTask extends DefaultTask {
 
         def prepared = header.prepare(file)
         if (prepared == null) {
-            logger.warn("No matching header format found for {}", getSimplifiedPath(file))
+            logger.info("No matching header format found for {}", getSimplifiedPath(file))
             return null
         }
 


### PR DESCRIPTION
Log missing headers/header formats on `INFO` instead on `WARNING`.