### PR TITLE
Modernize licenser's interactions with gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The plugin can be configured using the `license` extension on the project.
     ```gradle
     license {
         header = project.file('HEADER.txt')
-        ext {
+        properties {
             name = 'Company'
             year = 2018
         }
@@ -103,11 +103,11 @@ The plugin can be configured using the `license` extension on the project.
     license {
         tasks {
             gradle {
-                files = project.files('build.gradle.kts', 'settings.gradle.kts', 'gradle.properties')
+                files.from('build.gradle.kts', 'settings.gradle.kts', 'gradle.properties')
                 // header = ... (optional)
             }
             directory {
-                files = project.files('path/to/directory')
+                files.from('path/to/directory')
                 // include/exclude ... (optional)
             }
         }
@@ -127,15 +127,12 @@ The plugin can be configured using the `license` extension on the project.
 
     ```gradle
     license {
-        // Apply licenses only to main source set
-        sourceSets = [project.sourceSets.main]
-
-        // Apply licenses only to certain source sets on Android
-        androidSourceSets = [android.sourceSets.main]
-
         // Ignore failures and only print a warning on license violations
         ignoreFailures = true
 
         // Read/write files with platform charset (Default: UTF-8)
         charset = Charset.defaultCharset().name()
+  
+        // Override the line ending used for license files (Default: system line ending)
+        lineEnding = '\n'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -2,9 +2,9 @@ plugins {
     id 'java-gradle-plugin'
     id 'groovy'
 
-    id 'com.gradle.plugin-publish' version '0.12.0'
+    id 'com.gradle.plugin-publish' version '0.14.0'
 
-    id 'org.cadixdev.licenser' version '0.5.0'
+    id 'org.cadixdev.licenser' version '0.5.1'
 }
 
 sourceCompatibility = '1.8'

--- a/src/main/groovy/org/cadixdev/gradle/licenser/LicenseTaskProperties.groovy
+++ b/src/main/groovy/org/cadixdev/gradle/licenser/LicenseTaskProperties.groovy
@@ -24,8 +24,12 @@
 
 package org.cadixdev.gradle.licenser
 
+import groovy.transform.PackageScope
 import org.gradle.api.Incubating
-import org.gradle.api.file.FileCollection
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import org.gradle.api.resources.TextResourceFactory
 import org.gradle.api.tasks.util.PatternSet
 
 /**
@@ -43,11 +47,13 @@ class LicenseTaskProperties extends LicenseProperties {
     /**
      * The set of files to operate on.
      */
-    FileCollection files
+    final ConfigurableFileCollection files
 
-    LicenseTaskProperties(PatternSet filter, String name) {
-        super(filter)
+    @PackageScope
+    LicenseTaskProperties(PatternSet filter, String name, ObjectFactory objects, TextResourceFactory text, Property<String> charset) {
+        super(filter, objects, text, charset)
         this.name = name
+        this.files = objects.fileCollection()
     }
 
 }

--- a/src/main/groovy/org/cadixdev/gradle/licenser/Licenser.groovy
+++ b/src/main/groovy/org/cadixdev/gradle/licenser/Licenser.groovy
@@ -24,19 +24,24 @@
 
 package org.cadixdev.gradle.licenser
 
-import static org.gradle.api.plugins.JavaBasePlugin.CHECK_TASK_NAME
-
 import groovy.text.SimpleTemplateEngine
 import org.cadixdev.gradle.licenser.header.Header
 import org.cadixdev.gradle.licenser.tasks.LicenseCheck
 import org.cadixdev.gradle.licenser.tasks.LicenseTask
 import org.cadixdev.gradle.licenser.tasks.LicenseUpdate
+import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.file.FileCollection
 import org.gradle.api.plugins.JavaBasePlugin
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.resources.ResourceException
+import org.gradle.api.resources.TextResource
 import org.gradle.api.tasks.SourceSet
+import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.util.PatternSet
+import org.gradle.language.base.plugins.LifecycleBasePlugin
+import org.gradle.util.ConfigureUtil
 
 class Licenser implements Plugin<Project> {
 
@@ -44,6 +49,7 @@ class Licenser implements Plugin<Project> {
     private static final String FORMAT_TASK = 'updateLicense'
     private static final String ANDROID_TASK = 'Android'
     private static final String CUSTOM_TASK = 'Custom'
+    private static final String FORMATTING_GROUP = 'formatting'
 
     private Project project
     private LicenseExtension extension
@@ -53,66 +59,105 @@ class Licenser implements Plugin<Project> {
         this.project = project
 
         project.with {
-            this.extension = extensions.create('license', LicenseExtension, project)
-            extension.header = project.file('LICENSE')
+            this.extension = extensions.create('license', LicenseExtension, project.objects, project)
+            extension.header.set(extension.charset.map { charset -> project.resources.text.fromFile('LICENSE', charset) })
+
+            def headers = objects.listProperty(Header)
+            // TODO: finalizeValueOnRead is not supported on Gradle 5, remove when dropping support
+            try {
+                extension.conditionalProperties.finalizeValueOnRead()
+                headers.finalizeValueOnRead()
+            } catch (final MissingMethodException ignored) {
+                // no method
+            }
+            headers.set(extension.conditionalProperties.map {
+                def built = []
+                it.reverseEach { props ->
+                    built << prepareHeader(extension, props)
+                }
+                built << prepareHeader(extension, extension)
+                return built
+            })
+
+            // Configure tasks from different sources
             plugins.withType(JavaBasePlugin) {
-                extension.sourceSets = project.sourceSets
+                sourceSets.all { SourceSet set ->
+                    def extensionIgnoreFailures = extension.ignoreFailures
+                    def extensionLineEnding = extension.lineEnding
+                    createTask(CHECK_TASK, LicenseCheck, headers, set) {
+                        ignoreFailures.set(extensionIgnoreFailures)
+                    }
+                    createTask(FORMAT_TASK, LicenseUpdate, headers, set) {
+                        lineEnding.set(extensionLineEnding)
+                    }
+                }
             }
 
             ['com.android.library', 'com.android.application'].each {
                 plugins.withId(it) {
-                    extension.androidSourceSets = android.sourceSets
+                    android.sourceSets.all { set ->
+                        def extensionIgnoreFailures = extension.ignoreFailures
+                        def extensionLineEnding = extension.lineEnding
+                        createAndroidTask(CHECK_TASK, LicenseCheck, headers, set) {
+                            ignoreFailures.set(extensionIgnoreFailures)
+                        }
+                        createAndroidTask(FORMAT_TASK, LicenseUpdate, headers, set) {
+                            lineEnding.set(extensionLineEnding)
+                        }
+                    }
                 }
             }
 
-            def globalCheck = task(CHECK_TASK + 's')
-            task('licenseCheck', dependsOn: globalCheck)
-            def globalFormat = task(FORMAT_TASK + 's')
-            task('licenseFormat', dependsOn: globalFormat)
-
-            afterEvaluate {
-                project.tasks.findByName(CHECK_TASK_NAME)?.dependsOn globalCheck
+            extension.tasks.all { LicenseTaskProperties props ->
+                def extensionIgnoreFailures = extension.ignoreFailures
+                def extensionLineEnding = extension.lineEnding
+                createCustomTask(CHECK_TASK, LicenseCheck, props) {
+                    ignoreFailures.set(extensionIgnoreFailures)
+                }
+                createCustomTask(FORMAT_TASK, LicenseUpdate, props) {
+                    lineEnding.set(extensionLineEnding)
+                }
             }
 
-            // Wait a bit until creating the tasks
-            afterEvaluate {
-                def headers = []
-                extension.conditionalProperties.reverseEach {
-                    headers << prepareHeader(extension, it)
-                }
-                headers << prepareHeader(extension, extension)
+            // Then configure catch-all tasks
+            def globalCheck = tasks.register(CHECK_TASK + 's') {
+                dependsOn(tasks.withType(LicenseCheck))
+            }
+            tasks.register('licenseCheck') {
+                dependsOn(globalCheck)
+            }
+            def globalFormat = tasks.register(FORMAT_TASK + 's') {
+                dependsOn(tasks.withType(LicenseUpdate))
+            }
+            tasks.register('licenseFormat') {
+                group = FORMATTING_GROUP
+                dependsOn(globalFormat)
+            }
 
-                extension.sourceSets.each {
-                    def check = createTask(CHECK_TASK, LicenseCheck, headers, it)
-                    check.ignoreFailures = extension.ignoreFailures
-                    globalCheck.dependsOn check
-                    globalFormat.dependsOn createTask(FORMAT_TASK, LicenseUpdate, headers, it)
-                }
-
-                extension.androidSourceSets.each {
-                    def check = createAndroidTask(CHECK_TASK, LicenseCheck, headers, it)
-                    check.ignoreFailures = extension.ignoreFailures
-                    globalCheck.dependsOn check
-                    globalFormat.dependsOn createAndroidTask(FORMAT_TASK, LicenseUpdate, headers, it)
-                }
-
-                extension.tasks.each {
-                    def check = createCustomTask(CHECK_TASK, LicenseCheck, it)
-                    check.ignoreFailures = extension.ignoreFailures
-                    globalCheck.dependsOn check
-                    globalFormat.dependsOn createCustomTask(FORMAT_TASK, LicenseUpdate, it)
+            plugins.withType(LifecycleBasePlugin) {
+                tasks.named(LifecycleBasePlugin.CHECK_TASK_NAME).configure {
+                    dependsOn globalCheck
                 }
             }
         }
     }
 
     private static Header prepareHeader(LicenseExtension extension, LicenseProperties properties) {
-        return new Header(extension.style, extension.keywords, {
-            File header = properties.header ?: extension.header
-            if (header != null && header.exists()) {
-                def text = header.getText(extension.charset)
+        def headerResource = properties.header.orElse(extension.header)
+        def extraProperties = extension.ext
+        extension.keywords.disallowChanges()
+        properties.newLine.disallowChanges()
+        return new Header(extension.style, extension.keywords, extension.providers.provider {
+            TextResource header = headerResource.getOrNull()
+            if (header != null) {
+                def text
+                try {
+                    text = header.asString()
+                } catch (ResourceException ignored) {
+                    return ""
+                }
 
-                Map<String, String> props = extension.ext.properties
+                Map<String, String> props = extraProperties.properties
                 if (props) {
                     def engine = new SimpleTemplateEngine()
                     def template = engine.createTemplate(text).make(props)
@@ -123,33 +168,63 @@ class Licenser implements Plugin<Project> {
             }
 
             return ""
-        }, (PatternSet) properties.filter, properties.newLine ?: extension.newLine,)
+        }, (PatternSet) properties.filter, properties.newLine.orElse(extension.newLine),)
     }
 
-    private <T extends LicenseTask> T createTask(String name, Class<T> type, List<Header> headers, SourceSet sourceSet) {
-        return makeTask(sourceSet.getTaskName(name, null), type, headers, sourceSet.allSource)
+    private <T extends LicenseTask> TaskProvider<T> createTask(
+            String name,
+            @DelegatesTo.Target Class<T> type,
+            ListProperty<Header> headers,
+            SourceSet sourceSet,
+            @DelegatesTo(strategy = Closure.DELEGATE_FIRST) Closure target = null
+    ) {
+        return makeTask(sourceSet.getTaskName(name, null), type, headers, sourceSet.allSource, target)
     }
 
-    private <T extends LicenseTask> T createAndroidTask(String name, Class<T> type, List<Header> headers, Object sourceSet) {
+    private <T extends LicenseTask> TaskProvider<T> createAndroidTask(
+            String name,
+            @DelegatesTo.Target Class<T> type,
+            ListProperty<Header> headers,
+            Object sourceSet,
+            @DelegatesTo(strategy = Closure.DELEGATE_FIRST) Closure target = null
+    ) {
         return makeTask(name + ANDROID_TASK + sourceSet.name.capitalize(), type, headers,
-                project.files(sourceSet.java.sourceFiles, sourceSet.res.sourceFiles, sourceSet.manifest.srcFile))
+                project.files(sourceSet.java.sourceFiles, sourceSet.res.sourceFiles, sourceSet.manifest.srcFile), target)
     }
 
-    private <T extends LicenseTask> T createCustomTask(String name, Class<T> type, LicenseTaskProperties properties) {
-        def headers = [prepareHeader(extension, properties)]
-        def task = makeTask(name + CUSTOM_TASK + properties.name.capitalize(), type, headers, properties.files)
-        task.filter = properties.filter
+    private <T extends LicenseTask> TaskProvider<T> createCustomTask(
+            String name,
+            @DelegatesTo.Target Class<T> type,
+            LicenseTaskProperties properties,
+            @DelegatesTo(strategy = Closure.DELEGATE_FIRST) Closure target = null
+    ) {
+        def headers = project.objects.listProperty(Header)
+        headers.add(prepareHeader(extension, properties))
+        def task = makeTask(name + CUSTOM_TASK + properties.name.capitalize(), type, headers, properties.files, target)
+        task.configure {
+            filter = properties.filter
+        }
         return task
-
     }
 
-    private <T extends LicenseTask> T makeTask(String name, Class<T> type, List<Header> headers, FileCollection files) {
-        return (T) project.task(name, type: type) { T task ->
-            task.headers = headers
+    private <T extends LicenseTask> TaskProvider<T> makeTask(
+            String name,
+            Class<T> type,
+            ListProperty<Header> headers,
+            FileCollection files,
+            Closure target = null
+    ) {
+        def charset = extension.charset
+        def skipExisting = extension.skipExistingHeaders
+        return project.tasks.register(name, type) { T task ->
+            task.headers.set(headers)
             task.files = files
             task.filter = extension.filter
-            task.charset = extension.charset
-            task.skipExistingHeaders = extension.skipExistingHeaders
+            task.charset.set(charset)
+            task.skipExistingHeaders.set(skipExisting)
+            if (target != null) {
+                ConfigureUtil.configure(target, task)
+            }
         }
     }
 

--- a/src/main/groovy/org/cadixdev/gradle/licenser/header/CommentHeaderFormat.groovy
+++ b/src/main/groovy/org/cadixdev/gradle/licenser/header/CommentHeaderFormat.groovy
@@ -24,6 +24,7 @@
 
 package org.cadixdev.gradle.licenser.header
 
+import groovy.transform.PackageScope
 import org.cadixdev.gradle.licenser.util.HeaderHelper
 
 import javax.annotation.Nullable
@@ -43,6 +44,7 @@ class CommentHeaderFormat implements HeaderFormat {
     final String prefix
     final String lastLine
 
+    @PackageScope
     CommentHeaderFormat(String name, Pattern start, @Nullable Pattern end, @Nullable Pattern skipLine,
                         String firstLine, String prefix, String lastLine) {
         this.name = name

--- a/src/main/groovy/org/cadixdev/gradle/licenser/header/PreparedHeader.java
+++ b/src/main/groovy/org/cadixdev/gradle/licenser/header/PreparedHeader.java
@@ -31,6 +31,6 @@ public interface PreparedHeader {
 
     boolean check(File file, String charset, boolean skipExistingHeaders) throws IOException;
 
-    boolean update(File file, String charset, boolean skipExistingHeaders, Runnable callback) throws IOException;
+    boolean update(File file, String charset, String lineSeparator, boolean skipExistingHeaders, Runnable callback) throws IOException;
 
 }

--- a/src/test/groovy/org/cadixdev/gradle/licenser/LicenseExtensionTest.groovy
+++ b/src/test/groovy/org/cadixdev/gradle/licenser/LicenseExtensionTest.groovy
@@ -32,7 +32,7 @@ class LicenseExtensionTest extends Specification {
     def "style closure registers header style"() {
         given:
         def project = ProjectBuilder.builder().build()
-        def licenseExtension = new LicenseExtension(project)
+        def licenseExtension = new LicenseExtension(project.objects, project)
 
         when:
         licenseExtension.style {


### PR DESCRIPTION
This is the beginnings of work to modernize the licenser plugin so that it's a better Gradle citizen and supports new features that they add.

So far, this:
- Switches to lazy task registration for licenser tasks
- Adds support for the configuration cache (#14)
- Makes the functional tests run on a variety of Gradle versions
- Update functional tests to use new Property-based API
- Expand use of lazy properties and refactor plugin init so that licenser tasks can be registered as soon as the associated source sets are created, rather than in an `afterEvaluate` block (#16)
- Sort out line endings issues in functional tests (project is checked out as LF, licenser uses system line endings by default) (#24)

Further items to work on are:

- ~~Ensure binary compatibility with Groovy's auto-generated methods~~
- ~~Work on making sure the newly chosen names aren't too silly~~

