### PR TITLE
Add `DOUBLE_SLASH` HeaderStyle

### DIFF
--- a/src/main/groovy/org/cadixdev/gradle/licenser/header/HeaderStyle.groovy
+++ b/src/main/groovy/org/cadixdev/gradle/licenser/header/HeaderStyle.groovy
@@ -33,7 +33,8 @@ enum HeaderStyle {
     JAVADOC(~/^\s*\/\*\*(?:[^*].*)?$/, ~/\*\/\s*(.*?)$/, null, '/**', ' *', ' */'),
     HASH(~/^\s*#/, null, ~/^\s*#!/, '#', '#', '#', 'properties', 'yml', 'yaml', 'sh'),
     XML(~/^\s*<!--/, ~/-->\s*(.*?)$/, ~/^\s*<(?:\?xml .*\?|!DOCTYPE .*)>\s*$/, '<!--', '   ', '-->',
-            'xml', 'xsd', 'xsl', 'fxml', 'dtd', 'html', 'xhtml')
+            'xml', 'xsd', 'xsl', 'fxml', 'dtd', 'html', 'xhtml'),
+    DOUBLE_SLASH(~/^\s*\/\//, null, null, '//', '//', '//')
 
     final CommentHeaderFormat format
     private final String[] extensions


### PR DESCRIPTION
Adds the `DOUBLE_SLASH` header style.

See an example of the format here: https://github.com/Incendo/cloud/blob/3960727b2a7c33a75454cb42f1c8e46cb4e7362d/cloud-core/src/main/java/cloud/commandframework/CommandTree.java#L1-L23