### PR TITLE
Make Licenser plugin work with Gradle 7.1

### DIFF
--- a/src/functionalTest/groovy/org/cadixdev/gradle/licenser/LicenserPluginFunctionalTest.groovy
+++ b/src/functionalTest/groovy/org/cadixdev/gradle/licenser/LicenserPluginFunctionalTest.groovy
@@ -43,7 +43,9 @@ class LicenserPluginFunctionalTest extends Specification {
             // TODO: restore android plugin once versions that support configuration cache are available
             /* gradleVersion | androidVersion | extraArgs */
             [ "6.8.3",         null,            ["--configuration-cache"] ],
-            [ "7.0",           null,            ["--configuration-cache"] ],
+            [ "6.9",           null,            ["--configuration-cache"] ],
+            [ "7.0.2",         null,            ["--configuration-cache"] ],
+            [ "7.1",           null,            ["--configuration-cache"] ],
     ].asImmutable()
 
     static final def testMatrix = ([


### PR DESCRIPTION
Gradle 7.1 introduced some changes which caused `project.extensions.create('license', LicenseExtension, project.objects, project)` to return `DefaultBasePluginExtension` (introduced in Gradle 7.1) instead of `LicenseExtension` which would lead to an exception when trying to access a property of `LicenseExtension` on the returned instance.

The issue was traced back to using `project.with { ... }` and not properly resolving the instance variables and field accessors inside that block.

By moving everything out of the `project.with { ... }` block, the field accessor for `Licenser.extension` is properly resolved.