### PR TITLE
Support files without extensions

### DIFF
--- a/src/functionalTest/groovy/org/cadixdev/gradle/licenser/LicenserPluginFunctionalTest.groovy
+++ b/src/functionalTest/groovy/org/cadixdev/gradle/licenser/LicenserPluginFunctionalTest.groovy
@@ -321,6 +321,53 @@ class LicenserPluginFunctionalTest extends Specification {
     }
 
     @Unroll
+    def "support mapping without extension (gradle #gradleVersion)"() {
+        given:
+        def projectDir = temporaryFolder.newFolder()
+        def sourcesDir = new File(projectDir, "sources")
+        sourcesDir.mkdirs()
+        new File(projectDir, "settings.gradle") << ""
+        new File(projectDir, "header.txt") << "Copyright header"
+        def sourceFile = new File(sourcesDir, "Specialfile") << "TEST"
+        new File(projectDir, "build.gradle") << """
+            plugins {
+                id('org.cadixdev.licenser')
+            }
+            
+            license {
+                lineEnding = '\\n'
+                header = project.file("header.txt")
+                newLine = false
+                style {
+                    Specialfile = 'HASH'
+                }
+                tasks {
+                    sources {
+                        files.from("sources")
+                    }
+                }
+            }
+        """.stripIndent()
+
+        when:
+        def runner = runner(projectDir, gradleVersion, extraArgs + "updateLicenses")
+        runner.debug = true
+        def result = runner.build()
+
+        then:
+        result.task(":updateLicenseCustomSources").outcome == TaskOutcome.SUCCESS
+        sourceFile.text == """\
+            #
+            # Copyright header
+            #
+            TEST
+            """.stripIndent()
+
+        where:
+        [gradleVersion, _, extraArgs] << testMatrix
+    }
+
+    @Unroll
     def "license formatting configuration is configuration-cacheable (gradle #gradleVersion)"() {
         given:
         def projectDir = temporaryFolder.newFolder()

--- a/src/main/groovy/org/cadixdev/gradle/licenser/header/HeaderStyle.groovy
+++ b/src/main/groovy/org/cadixdev/gradle/licenser/header/HeaderStyle.groovy
@@ -29,9 +29,10 @@ import java.util.regex.Pattern
 
 enum HeaderStyle {
     BLOCK_COMMENT(~/^\s*\/\*(?:[^*].*)?$/, ~/\*\/\s*(.*?)$/, null, '/*', ' *', ' */',
-        'java', 'groovy', 'scala', 'kt', 'kts', 'gradle', 'css', 'js'),
+        'java', 'groovy', 'scala', 'kt', 'kts', 'gradle', 'css', 'js', 'Jenkinsfile'),
     JAVADOC(~/^\s*\/\*\*(?:[^*].*)?$/, ~/\*\/\s*(.*?)$/, null, '/**', ' *', ' */'),
-    HASH(~/^\s*#/, null, ~/^\s*#!/, '#', '#', '#', 'properties', 'yml', 'yaml', 'sh'),
+    HASH(~/^\s*#/, null, ~/^\s*#!/, '#', '#', '#',
+            'properties', 'yml', 'yaml', 'sh', 'Dockerfile', 'Vagrantfile'),
     XML(~/^\s*<!--/, ~/-->\s*(.*?)$/, ~/^\s*<(?:\?xml .*\?|!DOCTYPE .*)>\s*$/, '<!--', '   ', '-->',
             'xml', 'xsd', 'xsl', 'fxml', 'dtd', 'html', 'xhtml'),
     DOUBLE_SLASH(~/^\s*\/\//, null, null, '//', '//', '//')

--- a/src/main/groovy/org/cadixdev/gradle/licenser/util/HeaderHelper.java
+++ b/src/main/groovy/org/cadixdev/gradle/licenser/util/HeaderHelper.java
@@ -28,6 +28,7 @@ import org.cadixdev.gradle.licenser.header.CommentHeaderFormat;
 
 import javax.annotation.Nullable;
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.regex.Pattern;
@@ -37,9 +38,15 @@ public final class HeaderHelper {
     private HeaderHelper() {
     }
 
-    public static String getExtension(String s) {
-        final int pos = s.lastIndexOf('.');
-        return pos >= 0 ? s.substring(pos + 1) : null;
+    public static String getExtension(String path) {
+        String filename = getFilename(path);
+        final int pos = filename.lastIndexOf('.');
+        return pos >= 0 ? filename.substring(pos + 1) : filename;
+    }
+
+    private static String getFilename(String path) {
+        final int pos = path.lastIndexOf(File.separatorChar);
+        return pos >= 0 ? path.substring(pos + 1) : path;
     }
 
     public static String stripIndent(String s) {

--- a/src/test/groovy/org/cadixdev/gradle/licenser/util/HeaderHelperTest.groovy
+++ b/src/test/groovy/org/cadixdev/gradle/licenser/util/HeaderHelperTest.groovy
@@ -29,6 +29,51 @@ import org.cadixdev.gradle.licenser.header.HeaderStyle
 import spock.lang.Specification
 
 class HeaderHelperTest extends Specification {
+
+    def "getExtension returns the extension"() {
+        given:
+        def filename = "App.java"
+
+        when:
+        def result = HeaderHelper.getExtension(filename)
+
+        then:
+        result == "java"
+    }
+
+    def "getExtension returns the whole filename without dot"() {
+        given:
+        def filename = "Dockerfile"
+
+        when:
+        def result = HeaderHelper.getExtension(filename)
+
+        then:
+        result == "Dockerfile"
+    }
+
+    def "getExtension returns filename from path"() {
+        given:
+        def path = "some/sub/path/Jenkinsfile"
+
+        when:
+        def result = HeaderHelper.getExtension(path)
+
+        then:
+        result == "Jenkinsfile"
+    }
+
+    def "getExtension returns the whole filename even if the path contains a dot"() {
+        given:
+        def path = "some.sub/path.with.dots/Vagrantfile"
+
+        when:
+        def result = HeaderHelper.getExtension(path)
+
+        then:
+        result == "Vagrantfile"
+    }
+
     def "contentStartsWithValidHeaderFormat returns false with empty input"() {
         given:
         def inputString = ""


### PR DESCRIPTION
Use the whole filename for mapping if the filename does not contain a dot. This is required to support files like Jenkinsfile, Dockerfile or Vagrantfile.