### PR TITLE
Add option to ignore the next line

### DIFF
--- a/src/functionalTest/groovy/org/cadixdev/gradle/licenser/LicenserPluginFunctionalTest.groovy
+++ b/src/functionalTest/groovy/org/cadixdev/gradle/licenser/LicenserPluginFunctionalTest.groovy
@@ -446,4 +446,61 @@ class LicenserPluginFunctionalTest extends Specification {
         [gradleVersion, _, extraArgs] << testMatrix
 
     }
+
+    @Unroll
+    def "ignore new line (gradle #gradleVersion)"() {
+        given:
+        def projectDir = temporaryFolder.newFolder()
+        def sourceDir = projectDir.toPath().resolve(Paths.get("src", "main", "java", "com", "example")).toFile()
+        sourceDir.mkdirs()
+        new File(projectDir, "header.txt") << "Copyright header"
+        new File(projectDir, "settings.gradle") << ""
+        new File(projectDir, "build.gradle") << """
+            plugins {
+                id('java')
+                id('org.cadixdev.licenser')
+            }
+
+            license {
+                lineEnding = '\\n'
+                header = project.file('header.txt')
+                ignoreNewLine = true
+            }
+        """.stripIndent()
+        new File(sourceDir, "One.java") << String.join("\n",
+                "/*",
+                " * Copyright header",
+                " */",
+                "   ",
+                "package com.example;",
+                "",
+                "class One {}",
+                ""
+        )
+        new File(sourceDir, "Two.java") << String.join("\n",
+                "/*",
+                " * Copyright header",
+                " */",
+                "",
+                "package com.example;",
+                "",
+                "class Two {}",
+                ""
+        )
+        new File(sourceDir, "Three.java") << String.join("\n",
+                "/*",
+                " * Copyright header",
+                " */",
+                "package com.example;",
+                "",
+                "class Three {}",
+                ""
+        )
+        when:
+        def result = runner(projectDir, gradleVersion, extraArgs + "checkLicenses").build()
+        then:
+        result.task(":checkLicenses").outcome == TaskOutcome.SUCCESS
+        where:
+        [gradleVersion, _, extraArgs] << testMatrix
+    }
 }

--- a/src/main/groovy/org/cadixdev/gradle/licenser/LicenseExtension.groovy
+++ b/src/main/groovy/org/cadixdev/gradle/licenser/LicenseExtension.groovy
@@ -138,6 +138,7 @@ class LicenseExtension extends LicenseProperties {
         }
         this.lineEnding = objects.property(String).convention(defaultLineEnding)
         this.newLine.convention(true)
+        this.ignoreNewLine.convention(false)
 
         // Files without standard comment format
         exclude '**/*.txt'

--- a/src/main/groovy/org/cadixdev/gradle/licenser/LicenseProperties.groovy
+++ b/src/main/groovy/org/cadixdev/gradle/licenser/LicenseProperties.groovy
@@ -59,6 +59,12 @@ class LicenseProperties implements PatternFilterable {
      */
     final Property<Boolean> newLine
 
+    /**
+     * Pay no attention to the line after the license header.
+     * By default this is {@code false}.
+     */
+    final Property<Boolean> ignoreNewLine
+
     protected final Property<String> charset
     private final TextResourceFactory resources
 
@@ -68,6 +74,7 @@ class LicenseProperties implements PatternFilterable {
         this.charset = objects.property(String)
         this.header = objects.property(TextResource)
         this.newLine = objects.property(Boolean)
+        this.ignoreNewLine = objects.property(Boolean)
         this.resources = resources
     }
 
@@ -103,6 +110,10 @@ class LicenseProperties implements PatternFilterable {
 
     void newLine(final Boolean newLine) {
         this.newLine.set(newLine)
+    }
+
+    void ignoreNewLine(final Boolean ignoreNewLine) {
+        this.ignoreNewLine.set(ignoreNewLine)
     }
 
 }

--- a/src/main/groovy/org/cadixdev/gradle/licenser/Licenser.groovy
+++ b/src/main/groovy/org/cadixdev/gradle/licenser/Licenser.groovy
@@ -167,7 +167,9 @@ class Licenser implements Plugin<Project> {
             }
 
             return ""
-        }, (PatternSet) properties.filter, properties.newLine.orElse(extension.newLine),)
+        }, (PatternSet) properties.filter,
+                properties.newLine.orElse(extension.newLine),
+                properties.ignoreNewLine.orElse(extension.ignoreNewLine))
     }
 
     private <T extends LicenseTask> TaskProvider<T> createTask(

--- a/src/main/groovy/org/cadixdev/gradle/licenser/header/Header.groovy
+++ b/src/main/groovy/org/cadixdev/gradle/licenser/header/Header.groovy
@@ -50,16 +50,20 @@ class Header {
     @Input
     final Provider<Boolean> newLine
 
+    @Input
+    final Provider<Boolean> ignoreNewLine
+
     private String text
 
     private final Map<HeaderFormat, PreparedHeader> formatted = new IdentityHashMap<>()
 
-    Header(HeaderFormatRegistry registry, ListProperty<String> keywords, Provider<String> loader, PatternSet filter, Provider<Boolean> newLine) {
+    Header(HeaderFormatRegistry registry, ListProperty<String> keywords, Provider<String> loader, PatternSet filter, Provider<Boolean> newLine, Provider<Boolean> ignoreNewLine) {
         this.registry = registry
         this.keywords = keywords.map { it*.toLowerCase() }
         this.loader = loader
         this.filter = filter?.asSpec ?: Specs.satisfyAll()
         this.newLine = newLine
+        this.ignoreNewLine = ignoreNewLine
     }
 
     @Input

--- a/src/main/groovy/org/cadixdev/gradle/licenser/header/PreparedCommentHeader.groovy
+++ b/src/main/groovy/org/cadixdev/gradle/licenser/header/PreparedCommentHeader.groovy
@@ -46,7 +46,7 @@ class PreparedCommentHeader implements PreparedHeader {
             boolean result = skipExistingHeaders ?
                     HeaderHelper.contentStartsWithValidHeaderFormat(reader, format) :
                     HeaderHelper.contentStartsWith(reader, this.lines.iterator(), format.skipLine)
-            if (result) {
+            if (result && !header.ignoreNewLine.get()) {
                 def line = reader.readLine()
                 if (header.newLine.get()) {
                     result = line != null && line.isEmpty()
@@ -212,7 +212,7 @@ class PreparedCommentHeader implements PreparedHeader {
             }
 
             // Look more carefully at the new lines
-            if (valid) {
+            if (valid && !header.ignoreNewLine.get()) {
                 if (header.newLine.get()) {
                     // Only valid if next line is empty
                     valid = last != null && last.isEmpty()


### PR DESCRIPTION
Add an option to ignore the next line after the license header. I'm not sure if this pr make #36 obsolete, but i think they complement each other well.

Sorry, for the many pull request but we try to migrate a lot of repositories from gradle 6 and [license-gradle-plugin](https://github.com/hierynomus/license-gradle-plugin) to gradle 7 and licenser. It would be really nice if we could complete the change with reformatting as little as possible.